### PR TITLE
Issue #25: error passing walltime around in the inherited classes

### DIFF
--- a/R/qsys_lsf.r
+++ b/R/qsys_lsf.r
@@ -10,8 +10,8 @@ LSF = R6::R6Class("LSF",
             private$set_common_data(fun=fun, const=const, seed=seed)
         },
 
-        submit_job = function(memory=NULL, log_worker=FALSE) {
-            values = super$submit_job(memory=memory, log_worker=log_worker)
+        submit_job = function(memory=NULL, walltime=NA, log_worker=FALSE) {
+            values = super$submit_job(memory=memory,walltime=walltime, log_worker=log_worker)
             job_input = infuser::infuse(LSF$template, values)
             system("bsub", input=job_input, ignore.stdout=TRUE)
         },

--- a/R/qsys_lsf.r
+++ b/R/qsys_lsf.r
@@ -11,7 +11,7 @@ LSF = R6::R6Class("LSF",
         },
 
         submit_job = function(memory=NULL, walltime=NA, log_worker=FALSE) {
-            values = super$submit_job(memory=memory,walltime=walltime, log_worker=log_worker)
+            values = super$submit_job(memory=memory, walltime=walltime, log_worker=log_worker)
             job_input = infuser::infuse(LSF$template, values)
             system("bsub", input=job_input, ignore.stdout=TRUE)
         },

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -10,8 +10,8 @@ SGE = R6::R6Class("SGE",
             private$set_common_data(fun=fun, const=const, seed=seed)
         },
 
-        submit_job = function(memory=NULL, log_worker=FALSE) {
-            values = super$submit_job(memory=memory, log_worker=log_worker)
+        submit_job = function(memory=NULL, walltime=NA, log_worker=FALSE) {
+            values = super$submit_job(memory=memory, walltime=NA, log_worker=log_worker)
             job_input = infuser::infuse(SGE$template, values)
             system("qsub", input=job_input, ignore.stdout=TRUE)
         },

--- a/R/qsys_slurm.r
+++ b/R/qsys_slurm.r
@@ -10,8 +10,8 @@ SLURM = R6::R6Class("SLURM",
             private$set_common_data(fun=fun, const=const, seed=seed)
         },
 
-        submit_job = function(memory=NULL, log_worker=FALSE) {
-            values = super$submit_job(memory=memory, log_worker=log_worker)
+        submit_job = function(memory=NULL, walltime=NA, log_worker=FALSE) {
+            values = super$submit_job(memory=memory, walltime=NA, log_worker=log_worker)
             job_input = infuser::infuse(SLURM$template, values)
             system("sbatch", input=job_input, ignore.stdout=TRUE)
         },

--- a/R/qsys_ssh.r
+++ b/R/qsys_ssh.r
@@ -38,7 +38,7 @@ SSH = R6::R6Class("SSH",
             private$set_common_data(redirect=msg$proxy)
         },
 
-        submit_job = function(memory=NULL, log_worker=FALSE) {
+        submit_job = function(memory=NULL,walltime = NA,  log_worker=FALSE) {
             if (is.null(private$master))
                 stop("Need to call listen_socket() first")
 

--- a/R/qsys_ssh.r
+++ b/R/qsys_ssh.r
@@ -38,7 +38,7 @@ SSH = R6::R6Class("SSH",
             private$set_common_data(redirect=msg$proxy)
         },
 
-        submit_job = function(memory=NULL,walltime = NA,  log_worker=FALSE) {
+        submit_job = function(memory=NULL, walltime=NA, log_worker=FALSE) {
             if (is.null(private$master))
                 stop("Need to call listen_socket() first")
 


### PR DESCRIPTION
as I mentioned in #25 walltime was generating an error in the derived classes. 
I solved this issue in the qsys_ssh.r and qsys_lsf.r 

Please note that
if `#BSUB-W {{ walltime }}` is in the template, then the user MUST provide a value for walltime. 
Unfortunately, the NA cannot be interpreted by LSF (nor NAN, NULL or an empty string). Using these values will cancel the submission of the job on the cluster and make R hang. 

I would suggest to either give a numeric default value for `walltime` or handle the NA case  before you call `infuse(value, template)`.