### PR TITLE
Supply a valid ignore.stderr argument to system()

### DIFF
--- a/R/qsys_lsf.r
+++ b/R/qsys_lsf.r
@@ -24,7 +24,7 @@ LSF = R6::R6Class("LSF",
         finalize = function() {
             if (!private$is_cleaned_up) {
                 system(paste("bkill -J", private$job_id),
-                       ignore.stdout=FALSE, ignore.stderr=clean)
+                       ignore.stdout=FALSE, ignore.stderr=FALSE)
                 private$is_cleaned_up = TRUE
             }
         }

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -24,7 +24,7 @@ SGE = R6::R6Class("SGE",
         finalize = function() {
             if (!private$is_cleaned_up) {
                 system(paste("qdel", private$job_id),
-                       ignore.stdout=FALSE, ignore.stderr=clean)
+                       ignore.stdout=FALSE, ignore.stderr=FALSE)
                 private$is_cleaned_up = TRUE
             }
         }

--- a/R/qsys_slurm.r
+++ b/R/qsys_slurm.r
@@ -24,7 +24,7 @@ SLURM = R6::R6Class("SLURM",
         finalize = function() {
             if (!private$is_cleaned_up) {
                 system(paste("scancel --jobname", private$job_id),
-                       ignore.stdout=FALSE, ignore.stderr=clean)
+                       ignore.stdout=FALSE, ignore.stderr=FALSE)
                 private$is_cleaned_up = TRUE
             }
         }


### PR DESCRIPTION
The `finalize()` method [no longer has a `clean` argument](https://github.com/mschubert/clustermq/blob/693da5ba8dcbe4cb58de1aed5cebd0134165195d/R/qsys_sge.r#L24) in the `develop` branch, yet `clean` is still passed to `ignore.stderr` in `system()`. The bug affects SGE, LFS, and SLURM. This PR sets `ignore.stderr` to `FALSE`. The change removes an error I have begun to observe in `drake`:

```r
library(drake)
load_mtcars_example()
clean(destroy = TRUE)
options(clustermq.scheduler = "sge", clustermq.template = "template.tmpl")
make(my_plan, parallelism = "clustermq_staged", jobs = 2, verbose = 0)
#> Error in system(paste("qdel", private$job_id), ignore.stdout = FALSE,  :
#>  'ignore.stderr' must be TRUE or FALSE
```
