### PR TITLE
slurm: Use `--name` instead of `--jobname`

### DIFF
--- a/R/qsys_slurm.r
+++ b/R/qsys_slurm.r
@@ -25,7 +25,7 @@ SLURM = R6::R6Class("SLURM",
 
         finalize = function(quiet = self$workers_running == 0) {
             if (!private$is_cleaned_up) {
-                system(paste("scancel --jobname", private$job_id),
+                system(paste("scancel --name", private$job_id),
                        ignore.stdout=quiet, ignore.stderr=quiet, wait=FALSE)
                 private$is_cleaned_up = TRUE
             }


### PR DESCRIPTION
For backwards compatibility with older versions of SLURM that only had `--name` and not `--jobname`. In current versions, `scancel --jobname` and `--name` are synonyms.

Closes #148