### PR TITLE
Add an option to get an interface's IP address

### DIFF
--- a/R/util.r
+++ b/R/util.r
@@ -30,11 +30,11 @@ bind_avail = function(socket, range, iface="tcp://*", n_tries=100) {
 #' @return  the host name as character string
 #' @keywords internal
 host = function(short=getOption("clustermq.short.host", TRUE), interface=getOption("clustermq.network.interface", NULL)) {
-    if (is.null(interface))
+    if (is.null(interface)) {
         host = Sys.info()["nodename"]
         if (short)
             host = strsplit(host, "\\.")[[1]][1]
-    else
+    } else {
         # If the user has specified an interface name, get the host's IP address
         # on that particular interface
         network_interface_details = system2("ifconfig", args=(interface), stdout=TRUE, stderr=FALSE)
@@ -42,6 +42,7 @@ host = function(short=getOption("clustermq.short.host", TRUE), interface=getOpti
         inet_vector = strsplit(inet_string, "\\s+")[[1]]
         pos = match("inet", inet_vector)
         host = inet_vector[pos+1]
+    }
     host
 }
 

--- a/R/util.r
+++ b/R/util.r
@@ -29,10 +29,19 @@ bind_avail = function(socket, range, iface="tcp://*", n_tries=100) {
 #' @param short  whether to use unqualified host name (before first dot)
 #' @return  the host name as character string
 #' @keywords internal
-host = function(short=getOption("clustermq.short.host", TRUE)) {
-    host = Sys.info()["nodename"]
-    if (short)
-        host = strsplit(host, "\\.")[[1]][1]
+host = function(short=getOption("clustermq.short.host", TRUE), interface=getOption("clustermq.network.interface", NULL)) {
+    if is.null(interface)
+        host = Sys.info()["nodename"]
+        if (short)
+            host = strsplit(host, "\\.")[[1]][1]
+    else
+        # If the user has specified an interface name, get the host's IP address
+        # on that particular interface
+        network_interface_details = system2("ifconfig", args=(interface), stdout=TRUE, stderr=FALSE)
+        inet_string = grep(" inet ", network_interface, value=TRUE)
+        inet_vector = strsplit(inet_string, "\\s+")[[1]]
+        pos = match("inet", inet_vector)
+        host = inet_vector[pos+1]
     host
 }
 

--- a/R/util.r
+++ b/R/util.r
@@ -38,7 +38,7 @@ host = function(short=getOption("clustermq.short.host", TRUE), interface=getOpti
         # If the user has specified an interface name, get the host's IP address
         # on that particular interface
         network_interface_details = system2("ifconfig", args=(interface), stdout=TRUE, stderr=FALSE)
-        inet_string = grep(" inet ", network_interface, value=TRUE)
+        inet_string = grep(" inet ", network_interface_details, value=TRUE)
         inet_vector = strsplit(inet_string, "\\s+")[[1]]
         pos = match("inet", inet_vector)
         host = inet_vector[pos+1]

--- a/R/util.r
+++ b/R/util.r
@@ -30,7 +30,7 @@ bind_avail = function(socket, range, iface="tcp://*", n_tries=100) {
 #' @return  the host name as character string
 #' @keywords internal
 host = function(short=getOption("clustermq.short.host", TRUE), interface=getOption("clustermq.network.interface", NULL)) {
-    if is.null(interface)
+    if (is.null(interface))
         host = Sys.info()["nodename"]
         if (short)
             host = strsplit(host, "\\.")[[1]][1]


### PR DESCRIPTION
@mschubert I don't know about portability, but this should work on most Macs and Linux machines, based on availability of `ifconfig`.