### PR TITLE
Improved PBS Template + Docs of PBS / Torque Schedulers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 * New option `clustermq.ssh.timeout` to set timeout for SSH proxy startup. (#157)
-* Updated PBS / Torque sections in _User Guide_ and _Readme_ (#184) (mstr3336)
-* Improved default PBS submission template (#184) (mstr3336)
+* Fixed default PBS submission template and PBS/Torque documentation (#184) (@mstr3336)
 
 # 0.8.8
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 * New option `clustermq.ssh.timeout` to set timeout for SSH proxy startup. (#157)
+* Updated PBS / Torque sections in _User Guide_ and _Readme_ (#184) (mstr3336)
+* Improved default PBS submission template (#184) (mstr3336)
 
 # 0.8.8
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ schedulers](https://mschubert.github.io/clustermq/articles/userguide.html#settin
 * [SGE](https://mschubert.github.io/clustermq/articles/userguide.html#sge) - *should work without setup*
 * [SLURM](https://mschubert.github.io/clustermq/articles/userguide.html#slurm) - *should work without setup*
 * [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
-  * **OR** you may use `options(clustermq.scheduler = "sge")` and provide your own template for [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque)
 * via [SSH](https://mschubert.github.io/clustermq/articles/userguide.html#ssh-connector) -
 *needs* `options(clustermq.scheduler="ssh", clustermq.ssh.host=<yourhost>)`
+
+Each scheduler will be interfaced [using a default template that can be customized.](https://mschubert.github.io/clustermq/articles/userguide.html
+)
 
 If you need specific [computing environments or
 containers](https://mschubert.github.io/clustermq/articles/userguide.html#environments),

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ schedulers](https://mschubert.github.io/clustermq/articles/userguide.html#settin
 * [SGE](https://mschubert.github.io/clustermq/articles/userguide.html#sge) - *should work without setup*
 * [SLURM](https://mschubert.github.io/clustermq/articles/userguide.html#slurm) - *should work without setup*
 * [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
+  * **OR** you may use `options(clustermq.scheduler = "sge")` and provide your own template for [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque)
 * via [SSH](https://mschubert.github.io/clustermq/articles/userguide.html#ssh-connector) -
 *needs* `options(clustermq.scheduler="ssh", clustermq.ssh.host=<yourhost>)`
 

--- a/inst/PBS.tmpl
+++ b/inst/PBS.tmpl
@@ -5,9 +5,8 @@
 #PBS -o {{ log_file | /dev/null }}
 #PBS -j oe
 
-# Uncomment if R / zeromq are environement modules
+# Uncomment if R is an environement module
 # module load R
-# module load zeromq
 
 # Uncomment to set the working directory
 # cd {{ workdir | "$PBS_O_WORKDIR" }}

--- a/inst/PBS.tmpl
+++ b/inst/PBS.tmpl
@@ -1,6 +1,9 @@
 #PBS -N {{ job_name }}
 #PBS -J 1-{{ n_jobs }}
-#PBS -l select=1:ncpus={{ cores | 1 }}:mpiprocs={{ cores | 1 }}:mem={{ memory | 4096 }}MB
+#PBS -l nodes=1:ppn={{ cores | 1 }}:mem={{ memory | 4096 }}MB
+# ppn=P is equivalent to ncpus=P:mpiprocs=P 
+# "New" syntax: #PBS -l select=1:ncpus={{ cores | 1 }}:mpiprocs={{ cores | 1 }}:mem={{ memory | 4096 }}MB
+
 #PBS -l walltime={{ walltime | 12:00:00 }}
 #PBS -o {{ log_file | /dev/null }}
 #PBS -j oe

--- a/inst/PBS.tmpl
+++ b/inst/PBS.tmpl
@@ -1,7 +1,16 @@
 #PBS -N {{ job_name }}
-#PBS -l nodes={{ n_jobs }}:ppn={{ cores | 1 }}
+#PBS -J 1-{{ n_jobs }}
+#PBS -l select=1:ncpus={{ cores | 1 }}:mpiprocs={{ cores | 1 }}:mem={{ memory | 4096 }}MB
+#PBS -l walltime={{ walltime | 12:00:00 }}
 #PBS -o {{ log_file | /dev/null }}
 #PBS -j oe
+
+# Uncomment if R / zeromq are environement modules
+# module load R
+# module load zeromq
+
+# Uncomment to set the working directory
+# cd {{ workdir | "$PBS_O_WORKDIR" }}
 
 ulimit -v $(( 1024 * {{ memory | 4096 }} ))
 CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -537,7 +537,7 @@ PBS template:
 ```{r eval=FALSE}
 options(
     clustermq.scheduler = "sge",
-    clustermq.template.lsf = "/path/to/file/below"
+    clustermq.template = "/path/to/file/below"
 )
 ```
 
@@ -546,14 +546,17 @@ one below.
 
 ```{r eval=FALSE}
 #PBS -N {{ job_name }}
-#PBS -l select=1:ncpus={{ cores | 1 }}
-#PBS -l walltime={{ walltime | 1:00:00 }}
-#PBS -q default
+#PBS -J 1-{{ n_jobs }}
+#PBS -l select=1:ncpus={{ cores | 1 }}:mpiprocs={{ cores | 1 }}:mem={{ memory | 4096 }}MB
+#PBS -l walltime={{ walltime | 12:00:00 }}
 #PBS -o {{ log_file | /dev/null }}
 #PBS -j oe
 
+#PBS -q default
+
 ulimit -v $(( 1024 * {{ memory | 4096 }} ))
 CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'
+
 ```
 
 In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
@@ -564,6 +567,13 @@ In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
 * For other options, see the PBS documentation. Do not change the identifiers
   in curly braces (`{{ ... }}`), as they are used to fill in the right
   variables.
+
+Or simply set `clustermq.scheduler` to use a default PBS template we have 
+provided as follows:
+
+```{r eval=FALSE}
+options(clustermq.scheduler = "PBS")
+```
 
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.
@@ -602,6 +612,13 @@ In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
 * For other options, see the Torque documentation. Do not change the
   identifiers in curly braces (`{{ ... }}`), as they are used to fill in the
   right variables.
+
+Or simply set `clustermq.scheduler` to use a default Torque template we have 
+provided as follows:
+
+```{r eval=FALSE}
+options(clustermq.scheduler = "Torque")
+```
 
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -568,8 +568,6 @@ In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
   in curly braces (`{{ ... }}`), as they are used to fill in the right
   variables.
 
-Or simply set `clustermq.scheduler` to use a default PBS template we have 
-provided as follows:
 
 ```{r eval=FALSE}
 options(clustermq.scheduler = "PBS")

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -531,12 +531,18 @@ the missing options.
 
 ### PBS {#PBS}
 
-In your `~/.Rprofile` on your computing cluster, use the SGE scheduler with a
-PBS template:
+In your `~/.Rprofile` on your computing cluster, use the PBS scheduler with the
+default PBS template:
+
+```{r eval=FALSE}
+options(clustermq.scheduler = "pbs")
+```
+
+To customize your PBS template, set `clustermq.template`.
 
 ```{r eval=FALSE}
 options(
-    clustermq.scheduler = "sge",
+    clustermq.scheduler = "pbs",
     clustermq.template = "/path/to/file/below"
 )
 ```
@@ -568,23 +574,24 @@ In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
   in curly braces (`{{ ... }}`), as they are used to fill in the right
   variables.
 
-
-```{r eval=FALSE}
-options(clustermq.scheduler = "PBS")
-```
-
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.
 
 ### Torque {#Torque}
 
-In your `~/.Rprofile` on your computing cluster, use the SGE scheduler with a
-Torque template:
+In your `~/.Rprofile` on your computing cluster, use the Torque scheduler with 
+the default Torque template, as provided by us:
+
+```{r eval=FALSE}
+options(clustermq.scheduler = "Torque")
+```
+
+To customize your Torque template, set `clustermq.template`.
 
 ```{r eval=FALSE}
 options(
-    clustermq.scheduler = "sge",
-    clustermq.template.lsf = "/path/to/file/below"
+    clustermq.scheduler = "Torque",
+    clustermq.template = "/path/to/file/below"
 )
 ```
 
@@ -610,13 +617,6 @@ In this file, `#PBS-*` defines command-line arguments to the `qsub` program.
 * For other options, see the Torque documentation. Do not change the
   identifiers in curly braces (`{{ ... }}`), as they are used to fill in the
   right variables.
-
-Or simply set `clustermq.scheduler` to use a default Torque template we have 
-provided as follows:
-
-```{r eval=FALSE}
-options(clustermq.scheduler = "Torque")
-```
 
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.


### PR DESCRIPTION
To resolve #184 
Explicitly state that setting "PBS/Torque" as scheduler means a default template will be used, 
Fix typo in usage section
Improve default PBS template, and template given in usage to submit array jobs
