### PR TITLE
Now qsys for PBS/Torque schedulers get the actual job_id

### DIFF
--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -13,14 +13,20 @@ SGE = R6::R6Class("SGE",
 
         submit_jobs = function(...) {
             opts = private$fill_options(...)
-            private$job_id = opts$job_name
+            private$job_name = opts$job_name
             filled = private$fill_template(opts)
 
-            success = system("qsub", input=filled, ignore.stdout=TRUE)
-            if (success != 0) {
+            output  = system2("qsub", input=filled, stdout = T)
+            
+            status = attr(output, "status")
+            success = (!length(status)) || (status != 0)
+            
+            if (!success) {
                 print(filled)
                 stop("Job submission failed with error code ", success)
             }
+            # The first thing printed to stdout by qsub is the id
+            private$job_id = output[1]
         },
 
         finalize = function(quiet=self$workers_running == 0) {
@@ -33,7 +39,8 @@ SGE = R6::R6Class("SGE",
     ),
 
     private = list(
-        job_id = NULL
+        job_name = NULL,
+        job_id   = NULL
     )
 )
 

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -16,17 +16,17 @@ SGE = R6::R6Class("SGE",
             private$job_name = opts$job_name
             filled = private$fill_template(opts)
 
-            output  = system2("qsub", input=filled, stdout = T)
+            private$qsub_stdout  = system2("qsub", input=filled, stdout = T)
             
-            status = attr(output, "status")
+            status = attr(private$qsub_stdout, "status")
             success = (!length(status)) || (status != 0)
             
             if (!success) {
                 print(filled)
                 stop("Job submission failed with error code ", success)
             }
-            # The first thing printed to stdout by qsub is the id
-            private$job_id = output[1]
+            
+            private$set_job_id()
         },
 
         finalize = function(quiet=self$workers_running == 0) {
@@ -40,7 +40,10 @@ SGE = R6::R6Class("SGE",
 
     private = list(
         job_name = NULL,
-        job_id   = NULL
+        job_id   = NULL,
+        qsub_stdout = NULL,
+        
+        set_job_id = function() {private$job_id = private$job_name}
     )
 )
 
@@ -51,6 +54,10 @@ PBS = R6::R6Class("PBS",
         initialize = function(..., template=getOption("clustermq.template", "PBS")) {
             super$initialize(..., template=template)
         }
+    ),
+    
+    private = list(
+      set_job_id = function() {private$job_id = private$qsub_output[1]}
     )
 )
 

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -16,9 +16,9 @@ SGE = R6::R6Class("SGE",
             private$job_name = opts$job_name
             filled = private$fill_template(opts)
 
-            private$qsub_stdout  = system2("qsub", input=filled, stdout=TRUE)
+            qsub_stdout  = system2("qsub", input=filled, stdout=TRUE)
             
-            status = attr(private$qsub_stdout, "status")
+            status = attr(qsub_stdout, "status")
             success = (is.null(status) || (status == 0))
             
             if (!success) {
@@ -26,7 +26,7 @@ SGE = R6::R6Class("SGE",
                 stop("Job submission failed with error code ", success)
             }
             
-            private$set_job_id()
+            private$set_job_id(qsub_stdout)
         },
 
         finalize = function(quiet=self$workers_running == 0) {
@@ -41,9 +41,10 @@ SGE = R6::R6Class("SGE",
     private = list(
         job_name = NULL,
         job_id   = NULL,
-        qsub_stdout = NULL,
         
-        set_job_id = function() private$job_id = private$job_name
+        # This implementation of set_job_id ignores input argument qsub_stdout
+        # as it can use job_name to refer to jobs in qdel
+        set_job_id = function(qsub_stdout) private$job_id = private$job_name
     )
 )
 
@@ -57,7 +58,7 @@ PBS = R6::R6Class("PBS",
     ),
     
     private = list(
-      set_job_id = function() private$job_id = private$qsub_stdout[1]
+      set_job_id = function(qsub_stdout) private$job_id = qsub_stdout[1]
     )
 )
 

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -57,7 +57,7 @@ PBS = R6::R6Class("PBS",
     ),
     
     private = list(
-      set_job_id = function() {private$job_id = private$qsub_output[1]}
+      set_job_id = function() {private$job_id = private$qsub_stdout[1]}
     )
 )
 

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -16,10 +16,10 @@ SGE = R6::R6Class("SGE",
             private$job_name = opts$job_name
             filled = private$fill_template(opts)
 
-            private$qsub_stdout  = system2("qsub", input=filled, stdout = T)
+            private$qsub_stdout  = system2("qsub", input=filled, stdout=TRUE)
             
             status = attr(private$qsub_stdout, "status")
-            success = (!length(status)) || (status != 0)
+            success = (is.null(status) || (status == 0))
             
             if (!success) {
                 print(filled)
@@ -43,7 +43,7 @@ SGE = R6::R6Class("SGE",
         job_id   = NULL,
         qsub_stdout = NULL,
         
-        set_job_id = function() {private$job_id = private$job_name}
+        set_job_id = function() private$job_id = private$job_name
     )
 )
 
@@ -57,12 +57,12 @@ PBS = R6::R6Class("PBS",
     ),
     
     private = list(
-      set_job_id = function() {private$job_id = private$qsub_stdout[1]}
+      set_job_id = function() private$job_id = private$qsub_stdout[1]
     )
 )
 
 TORQUE = R6::R6Class("TORQUE",
-    inherit = SGE,
+    inherit = PBS,
 
     public = list(
         initialize = function(..., template=getOption("clustermq.template", "TORQUE")) {


### PR DESCRIPTION
Aims to resolve #186 

I've performed the neccessary changes to extract the actual job id of the submitted worker / worker array for PBS systems, and I've made the assumption ( with a small amount of research ) that they also apply to SGE, and implemented it for the SGE superclass.

That said, I don't have an SGE scheduler, & the man page wasnt explicit about what exactly the stdout return of `qsub` is for SGE, but in any case, the man page DOES suggest that for SGE systems, `JOB_NAME` and `JOB_ID` are distinct values.