### PR TITLE
fix issue with formating of object size

### DIFF
--- a/R/qsys.r
+++ b/R/qsys.r
@@ -71,7 +71,8 @@ QSys = R6::R6Class("QSys",
             }
             private$common_data = rzmq::init.message(c(list(id="DO_SETUP"), args))
             private$size_common = object.size(args)
-            common_mb = format(private$size_common, units="Mb")
+            common_mb = format(private$size_common, units="MB", standard="SI")
+            common_mb = as.numeric(regmatches(common_mb, regexpr("^[[:digit:]]+\\.*[[:digit:]]*", common_mb)))
             if (common_mb > getOption("clustermq.data.warning", 1000))
                 warning("Common data is ", common_mb, ". Recommended limit ",
                         "is ", getOption("clustermq.data.warning"),


### PR DESCRIPTION
Hello, on my machine
```
            common_mb = format(private$size_common, units="Mb")
```
was worth 7700 bytes and the formatting returned NA NA
As such the warning was systematically raised
The bellow fixes it on my setup