### PR TITLE
Configure script can now install when package directory is not a git repo (Ie, when installing from github source in another R session)

### DIFF
--- a/configure
+++ b/configure
@@ -3,7 +3,6 @@ set -e
 
 ZEROMQ_VERSION="4.3.4"
 ZEROMQ_URL="https://github.com/zeromq/libzmq/releases/download/v${ZEROMQ_VERSION}/zeromq-${ZEROMQ_VERSION}.tar.gz"
-#ZEROMQ_URL="https://api.github.com/repos/zeromq/libzmq/tarball/v${ZEROMQ_VERSION}"
 
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$(${R_HOME}/bin/R CMD config CXXFLAGS)
@@ -16,7 +15,9 @@ PKG_LIBS="libzmq/src/.libs/libzmq.a"
 if [ "$(git rev-parse --is-inside-work-tree)" ]; then  
   git submodule update --init --recursive
 else
-  #git clone  https://github.com/zeromq/libzmq.git src/libzmq
+  # Since we aren't using submodules, use the tarball release, 
+  # which saves having to run autogen.sh
+
   curl -sL "$ZEROMQ_URL" -o src/libzmq.tar.gz && \
     tar xvzf src/libzmq.tar.gz --strip-components=1 -C src/libzmq && \
     rm src/libzmq.tar.gz
@@ -28,6 +29,8 @@ fi
 if [ ! -f src/libzmq/src/.libs/libzmq.a ]; then
   cd src/libzmq
 
+  # If installing from the cloned repo, we need to generate ./configure,
+  # but if installing from tarball it should just exist.
   if [ ! -f ./configure ]; then
     ./autogen.sh
   fi

--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@ if [ "$(git rev-parse --is-inside-work-tree)" ]; then
 else
   #git clone  https://github.com/zeromq/libzmq.git src/libzmq
   curl -sL "$ZEROMQ_URL" -o src/libzmq.tar.gz && \
-    tar xvzf -C src/libzmq src/libzmq.tar.gz --strip-components=1 && \
+    tar xvzf src/libzmq.tar.gz --strip-components=1 -C src/libzmq && \
     rm src/libzmq.tar.gz
 
   git clone  https://github.com/zeromq/cppzmq.git src/cppzmq

--- a/configure
+++ b/configure
@@ -17,7 +17,10 @@ if [ "$(git rev-parse --is-inside-work-tree)" ]; then
   git submodule update --init --recursive
 else
   #git clone  https://github.com/zeromq/libzmq.git src/libzmq
-  curl -sL "$ZEROMQ_URL" -o src/libzmq.tar.gz && tar xvzf src/libzmq.tar.gz
+  curl -sL "$ZEROMQ_URL" -o src/libzmq.tar.gz && \
+    tar xvzf -C src/libzmq src/libzmq.tar.gz --strip-components=1 && \
+    rm src/libzmq.tar.gz
+
   git clone  https://github.com/zeromq/cppzmq.git src/cppzmq
 fi
 

--- a/configure
+++ b/configure
@@ -8,7 +8,14 @@ CPPFLAGS=$(${R_HOME}/bin/R CMD config CPPFLAGS)
 PKG_CFLAGS="-DZMQ_STATIC -DZMQ_BUILD_DRAFT_API=1 -fPIC -Ilibzmq/include -Icppzmq"
 PKG_LIBS="libzmq/src/.libs/libzmq.a"
 
-git submodule update --init --recursive
+
+if [ "$(git rev-parse --is-inside-work-tree)" ]; then  
+  git submodule update --init --recursive
+else
+  git clone  https://github.com/zeromq/libzmq.git src/libzmq
+  git clone  https://github.com/zeromq/cppzmq.git src/cppzmq
+fi
+
 
 if [ ! -f src/libzmq/src/.libs/libzmq.a ]; then
   cd src/libzmq

--- a/configure
+++ b/configure
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+ZEROMQ_VERSION="4.3.4"
+ZEROMQ_URL="https://github.com/zeromq/libzmq/releases/download/v${ZEROMQ_VERSION}/zeromq-${ZEROMQ_VERSION}.tar.gz"
+
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$(${R_HOME}/bin/R CMD config CXXFLAGS)
 CPPFLAGS=$(${R_HOME}/bin/R CMD config CPPFLAGS)
@@ -12,14 +15,19 @@ PKG_LIBS="libzmq/src/.libs/libzmq.a"
 if [ "$(git rev-parse --is-inside-work-tree)" ]; then  
   git submodule update --init --recursive
 else
-  git clone  https://github.com/zeromq/libzmq.git src/libzmq
+  #git clone  https://github.com/zeromq/libzmq.git src/libzmq
+  curl "$ZEROMQ_URL" -o src/libzmq.tar.gz && tar xvzf src/libzmq.tar.gz
   git clone  https://github.com/zeromq/cppzmq.git src/cppzmq
 fi
 
 
 if [ ! -f src/libzmq/src/.libs/libzmq.a ]; then
   cd src/libzmq
-  ./autogen.sh
+
+  if [ -f ./configure ]; then
+    ./autogen.sh
+  fi
+
   CXX="$CXX" CXXFLAGS="$CXXFLAGS -fPIC" CPPFLAGS="$CPPFLAGS" ./configure \
       --enable-static \
       --disable-shared \

--- a/configure
+++ b/configure
@@ -8,6 +8,8 @@ CPPFLAGS=$(${R_HOME}/bin/R CMD config CPPFLAGS)
 PKG_CFLAGS="-DZMQ_STATIC -DZMQ_BUILD_DRAFT_API=1 -fPIC -Ilibzmq/include -Icppzmq"
 PKG_LIBS="libzmq/src/.libs/libzmq.a"
 
+git submodule update --init --recursive
+
 if [ ! -f src/libzmq/src/.libs/libzmq.a ]; then
   cd src/libzmq
   ./autogen.sh

--- a/configure
+++ b/configure
@@ -28,7 +28,7 @@ fi
 if [ ! -f src/libzmq/src/.libs/libzmq.a ]; then
   cd src/libzmq
 
-  if [ -f ./configure ]; then
+  if [ ! -f ./configure ]; then
     ./autogen.sh
   fi
 

--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 set -e
 
 ZEROMQ_VERSION="4.3.4"
-ZEROMQ_URL="https://github.com/zeromq/libzmq/releases/download/v${ZEROMQ_VERSION}/zeromq-${ZEROMQ_VERSION}.tar.gz"
+ZEROMQ_URL="https://api.github.com/repos/zeromq/libzmq/tarball/v${ZEROMQ_VERSION}"
 
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$(${R_HOME}/bin/R CMD config CXXFLAGS)

--- a/configure
+++ b/configure
@@ -2,7 +2,8 @@
 set -e
 
 ZEROMQ_VERSION="4.3.4"
-ZEROMQ_URL="https://api.github.com/repos/zeromq/libzmq/tarball/v${ZEROMQ_VERSION}"
+ZEROMQ_URL="https://github.com/zeromq/libzmq/releases/download/v${ZEROMQ_VERSION}/zeromq-${ZEROMQ_VERSION}.tar.gz"
+#ZEROMQ_URL="https://api.github.com/repos/zeromq/libzmq/tarball/v${ZEROMQ_VERSION}"
 
 CXX=$(${R_HOME}/bin/R CMD config CXX)
 CXXFLAGS=$(${R_HOME}/bin/R CMD config CXXFLAGS)
@@ -16,7 +17,7 @@ if [ "$(git rev-parse --is-inside-work-tree)" ]; then
   git submodule update --init --recursive
 else
   #git clone  https://github.com/zeromq/libzmq.git src/libzmq
-  curl "$ZEROMQ_URL" -o src/libzmq.tar.gz && tar xvzf src/libzmq.tar.gz
+  curl -sL "$ZEROMQ_URL" -o src/libzmq.tar.gz && tar xvzf src/libzmq.tar.gz
   git clone  https://github.com/zeromq/cppzmq.git src/cppzmq
 fi
 


### PR DESCRIPTION
I'd recommend a squash for this one, half of my commits were me struggling with `curl` & `tar` options lmao.

Resolves #263 

On my HPC, build paths are a bit unreliable - though the hpc appears to provide a zeromq module, (4.1.3), for whatever reason, the relevant headers weren't being found when I tried to build from `master`.

I noticed that in `develop` you were bundling `zeromq`, so I decided to try it out

When installing this via `renv`, I would hit the following:

```r
renv::install("mschubert/clustermq@develop")
# paraphrasing
# configure 13: src/libzmq/autogen.sh not found
# error trace
```

I thought my HPC build tools were the problem for a bit, but with investigation, I realized that this was bc the submodules were not being initialized, so `src/libzmq` was empty.

To resolve this, we can explicitly tell it to initialize these submodules.
Doing this threw an error when installing via 

```r
renv::install("mschubert/clustermq@develop")
# paraphrasing
# configure: Not a git directory
# error trace
```

when installing via github, packages aren't pulled as repos, they're taken from release

When i tried to resolve this by cloning, I ran into another problem which was a bit more specific to my hpc build environment -

I just couldn't get `libzeromq/autogen.sh` to work properly. Rather than fix this, I figured it would be more reliable to skip the autogen step entirely by pulling from release & using the released `./configure` .