### PR TITLE
Update Makevars.win

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/$(OLDLIBDIR) \
 	-L$(RWINLIB)/lib$(R_ARCH) \
 	-L$(RWINLIB)/lib \
-	-lzmq -lsodium -liphlpapi -lws2_32
+	-lzmq -lsodium -lpthread -liphlpapi -lws2_32
 
 all: clean winlibs
 


### PR DESCRIPTION
Small tweak: on some toolchains we need to explicitly link pthread (used by zeromq). On other toolchains this is ignored so it is safe to add it unconditionally.