### PR TITLE
ENH: Add skip conditions to unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     rmarkdown,
     roxygen2 (>= 5.0.0),
     testthat,
+    tibble,
     tools
 VignetteBuilder: knitr
 Roxygen: list(r6 = FALSE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Suggests:
     rmarkdown,
     roxygen2 (>= 5.0.0),
     testthat,
-    tibble,
     tools
 VignetteBuilder: knitr
 Roxygen: list(r6 = FALSE)

--- a/tests/testthat/test-3-work_chunk.r
+++ b/tests/testthat/test-3-work_chunk.r
@@ -1,6 +1,8 @@
 context("work_chunk")
 
-df = as.data.frame(dplyr::tibble(
+skip_if_not_installed("tibble")
+
+df = as.data.frame(tibble::tibble(
     a = 1:3,
     b = as.list(letters[1:3]),
     c = setNames(as.list(3:1), letters[1:3])

--- a/tests/testthat/test-3-work_chunk.r
+++ b/tests/testthat/test-3-work_chunk.r
@@ -1,8 +1,6 @@
 context("work_chunk")
 
-skip_if_not_installed("tibble")
-
-df = as.data.frame(tibble::tibble(
+df = structure(row.names=c(NA, -3), class="data.frame", .Data=list(
     a = 1:3,
     b = as.list(letters[1:3]),
     c = setNames(as.list(3:1), letters[1:3])

--- a/tests/testthat/test-8-foreach.r
+++ b/tests/testthat/test-8-foreach.r
@@ -1,5 +1,7 @@
 context("foreach")
 
+skip_if_not_installed("foreach")
+
 foreach = foreach::foreach
 `%dopar%` = foreach::`%dopar%`
 `%do%` = foreach::`%do%`


### PR DESCRIPTION
It would be preferable to have unit tests skip rather than fail when suggested dependencies are missing. This adds a condition for that, as well as exchanges use of `dplyr::tibble` with a `base::data.frame` equivalent.