### PR TITLE
Increase flexibility of network port mapping in clustermq

### DIFF
--- a/R/qsys_ssh.r
+++ b/R/qsys_ssh.r
@@ -55,7 +55,12 @@ SSH = R6::R6Class("SSH",
         fill_options = function(...) {
             args = list(...)
             args$local_port = sub(".*:", "", private$addr)
-            args$ssh.hpc_fwd_port = getOption("clustermq.ssh.hpc_fwd_port", sample(50000:55000, 1))
+            args$ssh.hpc_fwd_port = getOption(
+                "clustermq.ssh.hpc_fwd_port", 
+                sample(
+                    getOption("clustermq.ssh.hpc_fwd_port.range",50000:55000),1
+                )
+            )
             utils::modifyList(private$defaults, args)
         },
 

--- a/R/util.r
+++ b/R/util.r
@@ -7,7 +7,7 @@
 #' @keywords internal
 # @param short  Whether to use unqualified host name (before first dot)
 host = function(node=getOption("clustermq.host", Sys.info()["nodename"]),
-                ports=6000:9999, n=100) {
+                ports=getOption("clustermq.port.range", 6000:9999), n=100) {
     utils::head(sample(sprintf("tcp://%s:%i", node, ports)), n)
 }
 

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -287,7 +287,7 @@ time after you restart R.
       `ZeroMQ` host address (default is `Sys.info()["nodename"]`)
 * `clustermq.port.range` - A port range used by `clustermq` to initiate 
       connections. Must be in the form of `lower_port:upper_port`.
-      (Default: `5000:9999`)
+      (Default: `6000:9999`)
       Important: This option - when used with the ssh connector - must be 
       set as an option on the remote host. 
 * `clustermq.ssh.host` - The user name and host for
@@ -300,8 +300,8 @@ time after you restart R.
       start-up connection before timing out (default is `10` seconds)
 * `clustermq.ssh.hpc_fwd_port` - Port that will be opened for SSH reverse
       tunneling between the workers on the HPC and a local session
-      (default: one integer in the range of 50-55k, unless     
-      `clustermq.ssh.hpc_fwd_port.range` is defined)
+      (default: one integer randomly samples from the range between 50000 and
+      55000, unless `clustermq.ssh.hpc_fwd_port.range` is defined)
 * `clustermq.ssh.hpc_fwd_port.range` - Port range allowed for SSH reverse 
       tunneling between the workers on the HPC and a local session. 
       Must be in the form or `lower_port:upper_port`. 

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -285,6 +285,11 @@ time after you restart R.
       otherwise `"LOCAL"`)
 * `clustermq.host` - The name of the node or device for constructing the
       `ZeroMQ` host address (default is `Sys.info()["nodename"]`)
+* `clustermq.port.range` - A port range used by `clustermq` to initiate 
+      connections. Must be in the form of `lower_port:upper_port`.
+      (Default: `5000:9999`)
+      Important: This option - when used with the ssh connector - must be 
+      set as an option on the remote host. 
 * `clustermq.ssh.host` - The user name and host for
       [connecting to the HPC via SSH](#ssh-connector) (e.g. `user@host`); we
       recommend setting up SSH keys for password-less login
@@ -295,7 +300,12 @@ time after you restart R.
       start-up connection before timing out (default is `10` seconds)
 * `clustermq.ssh.hpc_fwd_port` - Port that will be opened for SSH reverse
       tunneling between the workers on the HPC and a local session
-      (default: one integer in the range of 50-55k)
+      (default: one integer in the range of 50-55k, unless     
+      `clustermq.ssh.hpc_fwd_port.range` is defined)
+* `clustermq.ssh.hpc_fwd_port.range` - Port range allowed for SSH reverse 
+      tunneling between the workers on the HPC and a local session. 
+      Must be in the form or `lower_port:upper_port`. 
+      (default: `50000:55000`)
 * `clustermq.worker.timeout` - The amount of time to wait (in seconds) for
       master-worker communication before timing out (default is to wait
       indefinitely)


### PR DESCRIPTION
At the moment, the ports used by `clustermq` are hard coded. By default, ports between 6000 and 9999 are used by `clustermq` and ports between 50000 and 55000 are used by the `ssh` connector for forwarding ssh sessions.

This PR will introduce two new options to `clustermq`, i.e.

- `clustermq.port.range`
- `clustermq.ssh.hpc_fwd_port.range`

both of which will make working with `clustermq` in environments with networking firewalls much easier. 