### PR TITLE
Add OCS/GCS backend support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/Makevars
 windows
 /doc/
 /Meta/
+.idea/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: clustermq
-Title: Evaluate Function Calls on HPC Schedulers (LSF, SGE, SLURM, PBS/Torque)
+Title: Evaluate Function Calls on HPC Schedulers (LSF, SGE, GCS, OCS, SLURM, PBS/Torque)
 Version: 0.9.9
 Authors@R: c(
     person('Michael', 'Schubert', email='mschu.dev@gmail.com',

--- a/R/clustermq-package.r
+++ b/R/clustermq-package.r
@@ -1,4 +1,4 @@
-#' Evaluate Function Calls on HPC Schedulers (LSF, SGE, SLURM)
+#' Evaluate Function Calls on HPC Schedulers (LSF, SGE, GCS, OCS, SLURM)
 #'
 #' Provides the \code{Q} function to send arbitrary function calls to
 #' workers on HPC schedulers without relying on network-mounted storage.

--- a/R/qsys_sge.r
+++ b/R/qsys_sge.r
@@ -66,56 +66,31 @@ OCS = R6::R6Class("OCS",
                               log_worker=FALSE, log_file=NULL, verbose=TRUE) {
             super$initialize(addr=addr, master=master, template=template)
 
-            # fill the template with options and required fields
             opts = private$fill_options(n_jobs=n_jobs, ...)
             filled = fill_template(private$template, opts, required=c("master", "n_jobs"))
+            qsub_stdout = system2("qsub", input=filled, stdout=TRUE)
 
-            private$job_name = opts$job_name
-            if (verbose)
-                message("Submitting ", n_jobs, " worker jobs to ", class(self)[1], " as ", sQuote(private$job_name), " ...")
-
-            # submit the job with qsub (stdin-based) and capture the output
-            # on success the output will contain the job id, on failure the error message
-            private$qsub_stdout = system2("qsub", input=filled, stdout=TRUE)
-
-            # check the return code and stop on error
-            status = attr(private$qsub_stdout, "status")
+            status = attr(qsub_stdout, "status")
             if (!is.null(status) && status != 0)
                 private$template_error(class(self)[1], status, filled)
 
-            # try to read the job ID from stdout. On error stop
-            private$job_id <- regmatches(private$qsub_stdout, regexpr("^[0-9]+", private$qsub_stdout))
+            private$job_id = regmatches(qsub_stdout, regexpr("^[0-9]+", qsub_stdout))
             if (length(private$job_id) == 0)
-                private$template_error(class(self)[1], private$qsub_stdout, filled)
+                private$template_error(class(self)[1], qsub_stdout, filled)
 
-            # if we got here, we have a job ID and can proceed
             if (verbose)
-               message("Submitted job has ID ", private$job_id)
+                message("Submitted ", n_jobs, " worker tasks to ", class(self)[1], " as array job ", private$job_id, " ...")
 
             private$master$add_pending_workers(n_jobs)
-            private$is_cleaned_up = FALSE
         },
 
         cleanup = function(success, timeout) {
-            # first call finalize to send qdel ...
-            private$finalize()
-
-            # ... then set the cleaned up flag to avoid sending qdel again
-            private$is_cleaned_up = success
+            system(paste("qdel", private$job_id), ignore.stdout=TRUE, ignore.stderr=TRUE, wait=FALSE)
         }
     ),
 
     private = list(
-        qsub_stdout = NULL,
-        job_name = NULL,
-        job_id = NULL,
-
-        finalize = function(quiet = TRUE) {
-            if (!private$is_cleaned_up) {
-                system(paste("qdel", private$job_id), ignore.stdout=quiet, ignore.stderr=quiet, wait=FALSE)
-            }
-            private$is_cleaned_up = TRUE
-        }
+        job_id   = NULL
     ),
 
     cloneable = FALSE

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,9 +10,9 @@
     qsys_default = toupper(getOption('clustermq.scheduler'))
 
     if (length(qsys_default) == 0) {
-        qname = c("SLURM", "LSF", "SGE", "LOCAL")
-        exec = Sys.which(c("sbatch", "bsub", "qsub"))
-        select = c(which(nchar(exec) > 0), 4)[1]
+        qname = c("SLURM", "LSF", "SGE", "GCS", "OCS", "LOCAL")
+        exec = Sys.which(c("sbatch", "bsub", "qsub", "qsub", "qsub"))
+        select = c(which(nchar(exec) > 0), 6)[1]
         qsys_default = qname[select]
     }
 
@@ -26,8 +26,7 @@
 #' @keywords internal
 .onAttach = function(libname, pkgname) {
     if (is.null(getOption("clustermq.scheduler"))) {
-        packageStartupMessage("* Option 'clustermq.scheduler' not set, ",
-                "defaulting to ", sQuote(qsys_default))
+        packageStartupMessage("* Option 'clustermq.scheduler' not set, ", "defaulting to ", sQuote(qsys_default))
         packageStartupMessage("--- see: https://mschubert.github.io/clustermq/articles/userguide.html#configuration")
     }
     if (!libzmq_has_draft()) {

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -12,7 +12,7 @@
     if (length(qsys_default) == 0) {
         qname = c("SLURM", "LSF", "SGE", "LOCAL")
         exec = Sys.which(c("sbatch", "bsub", "qsub"))
-        select = c(which(nchar(exec) > 0), 6)[1]
+        select = c(which(nchar(exec) > 0), 4)[1]
         qsys_default = qname[select]
     }
 

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,8 +10,8 @@
     qsys_default = toupper(getOption('clustermq.scheduler'))
 
     if (length(qsys_default) == 0) {
-        qname = c("SLURM", "LSF", "SGE", "GCS", "OCS", "LOCAL")
-        exec = Sys.which(c("sbatch", "bsub", "qsub", "qsub", "qsub"))
+        qname = c("SLURM", "LSF", "SGE", "LOCAL")
+        exec = Sys.which(c("sbatch", "bsub", "qsub"))
         select = c(which(nchar(exec) > 0), 6)[1]
         qsys_default = qname[select]
     }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ schedulers](https://mschubert.github.io/clustermq/articles/userguide.html#config
 * [SLURM](https://mschubert.github.io/clustermq/articles/userguide.html#slurm) - *should work without setup*
 * [LSF](https://mschubert.github.io/clustermq/articles/userguide.html#lsf) - *should work without setup*
 * [SGE](https://mschubert.github.io/clustermq/articles/userguide.html#sge) - *may require configuration*
+* [GCS](https://mschubert.github.io/clustermq/articles/userguide.html#gcs) - *works without setup*
+* [OCS](https://mschubert.github.io/clustermq/articles/userguide.html#ocs) - *works without setup*
 * [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
 * via [SSH](https://mschubert.github.io/clustermq/articles/userguide.html#ssh-connector) -
 *needs* `options(clustermq.scheduler="ssh", clustermq.ssh.host=<yourhost>)`

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ schedulers](https://mschubert.github.io/clustermq/articles/userguide.html#config
 * [SLURM](https://mschubert.github.io/clustermq/articles/userguide.html#slurm) - *should work without setup*
 * [LSF](https://mschubert.github.io/clustermq/articles/userguide.html#lsf) - *should work without setup*
 * [SGE](https://mschubert.github.io/clustermq/articles/userguide.html#sge) - *may require configuration*
-* [GCS](https://mschubert.github.io/clustermq/articles/userguide.html#gcs) - *works without setup*
-* [OCS](https://mschubert.github.io/clustermq/articles/userguide.html#ocs) - *works without setup*
+* [GCS](https://mschubert.github.io/clustermq/articles/userguide.html#gcs) - *needs* `options(clustermq.scheduler="GCS")`
+* [OCS](https://mschubert.github.io/clustermq/articles/userguide.html#ocs) - *needs* `options(clustermq.scheduler="OCS")` 
 * [PBS](https://mschubert.github.io/clustermq/articles/userguide.html#pbs)/[Torque](https://mschubert.github.io/clustermq/articles/userguide.html#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
 * via [SSH](https://mschubert.github.io/clustermq/articles/userguide.html#ssh-connector) -
 *needs* `options(clustermq.scheduler="ssh", clustermq.ssh.host=<yourhost>)`

--- a/inst/GCS.tmpl
+++ b/inst/GCS.tmpl
@@ -1,0 +1,49 @@
+# Submit client should only show the job ID of the new job on success
+#$ -terse
+
+# Name of the job visible in OCS
+#$ -N {{ job_name }}
+
+# Join error and output file.
+#$ -j y
+
+# Location of the output file
+#$ -o {{ log_file | /dev/null }}
+
+# Start R job in the working directory
+#$ -cwd
+
+# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required).
+# Depending on security settings might require a cluster manager to set
+# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
+#$ -V
+
+# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
+#$ -t 1-{{ n_jobs }}
+
+# Each array task will allocate one slot in the cluster, if not other specified.
+#$ -pe mytestpe {{ cores | 1 }}
+
+# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
+#$ -bunit C
+#$ -bamount {{ threads | 1 }}
+
+# Cores on a host are packed (cores on a die or chiplet sharing same NUMA node and caches if possible)
+#$ -bstrategy packed
+#$ -btype host
+
+# The scheduler will do the binding via *HWLOC*.
+# Change to *env* if scheduler should make binding decision but not do the binding itself.
+#$ -binstance set
+
+# Allows to set resource requests like memory (1 GB [in bytes])
+# to set runtime limits (1 hour [in seconds])
+# or to influence scheduler resource selection (job will be executed in all.q queue)
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q
+
+# Tag the job so that it can be identified later on (e.g. in a JSV script before
+# submission so the job can get adapted or for filtering later on)
+#$ -ac application=clustermq
+
+ulimit -v $(( 1024 * {{ memory | 4096 }} ))
+CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'

--- a/inst/OCS.tmpl
+++ b/inst/OCS.tmpl
@@ -1,0 +1,37 @@
+# Submit client should only show the job ID of the new job on success
+#$ -terse
+
+# Name of the job visible in OCS
+#$ -N {{ job_name }}
+
+# Join error and output file
+#$ -j y
+
+# Location of the output file
+#$ -o {{ log_file | /dev/null }}
+
+# Start R job in the working directory
+#$ -cwd
+
+# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required)
+# depending on security settings might require a cluster manager to set
+# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
+#$ -V
+
+# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
+#$ -t 1-{{ n_jobs }}
+
+# Each array task will allocate one slot in the cluster, if not other specified.
+#$ -pe mytestpe {{ cores | 1 }}
+
+# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
+#$ -bunit C
+#$ -bamount {{ threads | 1 }}
+
+# Allows to set resource requests like memory (default 1 GB in bytes)
+# to set runtime limits (default 1 hour in seconds)
+# or to influence scheduler resource selection (job will be executed in all.q)
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ runtime | 3600 }},q=all.q
+
+ulimit -v $(( 1024 * {{ memory | 4096 }} ))
+CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'

--- a/vignettes/faq.Rmd
+++ b/vignettes/faq.Rmd
@@ -71,7 +71,7 @@ Running 1 calculations (5 objs/19.4 Kb common; 1 calls/chunk) ...
 
 You will see this every time your jobs are queued but not yet started.
 Depending on how busy your HPC is, this may take a long time. You can check the
-queueing status of your jobs in the terminal with _e.g._ `qstat` (SGE), `bjobs`
+queueing status of your jobs in the terminal with _e.g._ `qstat` (SGE, GCS or OCS), `bjobs`
 (LSF), or `sinfo` (SLURM).
 
 If your jobs are already finished, this likely means that the `clustermq`
@@ -201,7 +201,7 @@ Alternatively, you can create a script that uses SSH to execute the scheduler
 on the login node. For this, you will need an SSH client in the container,
 [keys set up for password-less login](https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server),
 and create a script to call the scheduler on the login node via ssh (e.g.
-`~/bin/qsub` for SGE/PBS/Torque, `bsub` for LSF and `sbatch` for Slurm):
+`~/bin/qsub` for SGE/GCS/OCS/PBS/Torque, `bsub` for LSF and `sbatch` for Slurm):
 
 ```{sh eval=FALSE}
 #!/bin/bash

--- a/vignettes/technicaldocs.Rmd
+++ b/vignettes/technicaldocs.Rmd
@@ -46,6 +46,8 @@ functions for submitting and cleaning up jobs:
   |- Multicore
   |- LSF
   + SGE
+    |- GCS
+    |- OCS
     |- PBS
     |- Torque
   |- etc.

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -82,6 +82,8 @@ To set up a scheduler explicitly, see the following links:
 * [SLURM](#slurm) - *should work without setup*
 * [LSF](#lsf) - *should work without setup*
 * [SGE](#sge) - *may require configuration*
+* [GCS](#gcs) - *works without setup*
+* [OCS](#ocs) - *works without setup*
 * [PBS](#pbs)/[Torque](#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
 * you can suggest another scheduler by [opening an
   issue](https://github.com/mschubert/clustermq/issues)
@@ -284,7 +286,7 @@ time after you restart R.
 
 * `clustermq.scheduler` - One of the supported
       [`clustermq` schedulers](#configuration); options are `"LOCAL"`,
-      `"multiprocess"`, `"multicore"`, `"lsf"`, `"sge"`, `"slurm"`, `"pbs"`,
+      `"multiprocess"`, `"multicore"`, `"lsf"`, `"sge"`, `"gcs"`, `"ocs"`, `"slurm"`, `"pbs"`,
       `"Torque"`, or `"ssh"` (default is the HPC scheduler found in `$PATH`,
       otherwise `"LOCAL"`)
 * `clustermq.host` - The name of the node or device for constructing the
@@ -480,6 +482,159 @@ In this file, `#BSUB-*` defines command-line arguments to the `bsub` program.
 
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.
+
+
+### GCS
+
+Set the following options in your _R_ session that will submit jobs:
+
+```{r eval=FALSE}
+options(
+    clustermq.scheduler = "gcs",
+    clustermq.template = "/path/to/file/below" # if using your own template
+)
+```
+
+To supply your own template, save the contents below with any desired changes
+to a file and have `clustermq.template` point to it.
+
+```{sh eval=FALSE}
+# Name of the job visible in GCS
+#$ -N {{ job_name }}
+
+# Join error and output file.
+#$ -j y
+
+# Location of the output file
+#$ -o {{ log_file | /dev/null }}
+
+# Start R job in the working directory
+#$ -cwd
+
+# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required).
+# Depending on security settings might require a cluster manager to set
+# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
+#$ -V
+
+# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
+#$ -t 1-{{ n_jobs }}
+
+# Each array task will allocate one slot in the cluster, if not other specified.
+#$ -pe mytestpe {{ cores | 1 }}
+
+# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
+#$ -bunit C
+#$ -bamount {{ threads | 1 }}
+
+# Cores on a host are packed (cores on a die or chiplet sharing same NUMA node and caches if possible)
+#$ -bstrategy packed
+#$ -btype host
+
+# The scheduler will do the binding via *HWLOC*.
+# Change to *env* if scheduler should make binding decision but not do the binding itself.
+#$ -binstance set
+
+# Allows to set resource requests like memory (1 GB [in bytes])
+# to set runtime limits (1 hour [in seconds])
+# or to influence scheduler resource selection (job will be executed in all.q queue)
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q
+
+# Tag the job so that it can be identified later on (e.g. in a JSV script before
+# submission so the job can get adapted or for filtering later on)
+#$ -ac application=clustermq,hostname={{ master }}
+
+ulimit -v $(( 1024 * {{ memory | 4096 }} ))
+CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'
+```
+
+In this file, `#$-*` defines command-line arguments to the `qsub` program.
+
+* Used objects (mytestpe, all.q) in the template example are default objects
+  available after the default installation of GCS. Adapt the template to your
+  local setup if these objects are not available or if you want to use other
+  ones.
+* The mytestpe is limited to 5 slots as default. Increase as appropriate for
+  your cluster and needs.
+* For other options, see the [qsub man page](https://github.com/hpc-gridware/clusterscheduler/blob/master/doc/markdown/man/man1/submit.include.md)
+* Find more detailed documentation on the options in the GCS manuals part of
+  your product installation ($SGE_ROOT/doc/pdf)
+* Do not change the identifiers in curly braces (`{{ ... }}`), as they are
+  used to fill in the right variables.
+
+Once this is done, the package will use your settings and no longer warn you of
+the missing options.
+
+
+### OCS
+
+Set the following options in your _R_ session that will submit jobs:
+
+```{r eval=FALSE}
+options(
+    clustermq.scheduler = "ocs",
+    clustermq.template = "/path/to/file/below" # if using your own template
+)
+```
+
+To supply your own template, save the contents below with any desired changes
+to a file and have `clustermq.template` point to it.
+
+```{sh eval=FALSE}
+# Name of the job visible in GCS
+#$ -N {{ job_name }}
+
+# Join error and output file.
+#$ -j y
+
+# Location of the output file
+#$ -o {{ log_file | /dev/null }}
+
+# Start R job in the working directory
+#$ -cwd
+
+# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required).
+# Depending on security settings might require a cluster manager to set
+# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
+#$ -V
+
+# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
+#$ -t 1-{{ n_jobs }}
+
+# Each array task will allocate one slot in the cluster, if not other specified.
+#$ -pe mytestpe {{ cores | 1 }}
+
+# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
+#$ -bunit C
+#$ -bamount {{ threads | 1 }}
+
+# Allows to set resource requests like memory (1 GB [in bytes])
+# to set runtime limits (1 hour [in seconds])
+# or to influence scheduler resource selection (job will be executed in all.q queue)
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q
+
+# Tag the job so that it can be identified later on (e.g. in a JSV script before
+# submission so the job can get adapted or for filtering later on)
+#$ -ac application=clustermq,hostname={{ master }}
+
+ulimit -v $(( 1024 * {{ memory | 4096 }} ))
+CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'
+```
+
+In this file, `#$-*` defines command-line arguments to the `qsub` program.
+
+* Used objects (mytestpe, all.q) in the template example are default objects
+  available after the default installation of GCS. Adapt the template to your
+  local setup if these objects are not available or if you want to use other
+  ones.
+* The mytestpe is limited to 5 slots as default. Increase as appropriate for
+  your cluster and needs.
+* For other options, see the [qsub man page](https://github.com/hpc-gridware/clusterscheduler/blob/master/doc/markdown/man/man1/submit.include.md)
+* Do not change the identifiers in curly braces (`{{ ... }}`), as they are
+  used to fill in the right variables.
+
+Once this is done, the package will use your settings and no longer warn you of
+the missing options.
+
 
 ### SGE
 

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -82,8 +82,8 @@ To set up a scheduler explicitly, see the following links:
 * [SLURM](#slurm) - *should work without setup*
 * [LSF](#lsf) - *should work without setup*
 * [SGE](#sge) - *may require configuration*
-* [GCS](#gcs) - *works without setup*
-* [OCS](#ocs) - *works without setup*
+* [GCS](#gcs) - *needs* `options(clustermq.scheduler="GCS")`
+* [OCS](#ocs) -  *needs* `options(clustermq.scheduler="OCS")`
 * [PBS](#pbs)/[Torque](#torque) - *needs* `options(clustermq.scheduler="PBS"/"Torque")`
 * you can suggest another scheduler by [opening an
   issue](https://github.com/mschubert/clustermq/issues)
@@ -500,48 +500,24 @@ to a file and have `clustermq.template` point to it.
 
 ```{sh eval=FALSE}
 # Name of the job visible in GCS
-#$ -N {{ job_name }}
-
-# Join error and output file.
-#$ -j y
-
-# Location of the output file
-#$ -o {{ log_file | /dev/null }}
-
-# Start R job in the working directory
-#$ -cwd
-
-# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required).
-# Depending on security settings might require a cluster manager to set
-# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
-#$ -V
-
-# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
-#$ -t 1-{{ n_jobs }}
-
-# Each array task will allocate one slot in the cluster, if not other specified.
-#$ -pe mytestpe {{ cores | 1 }}
-
-# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
-#$ -bunit C
-#$ -bamount {{ threads | 1 }}
-
-# Cores on a host are packed (cores on a die or chiplet sharing same NUMA node and caches if possible)
-#$ -bstrategy packed
-#$ -btype host
-
-# The scheduler will do the binding via *HWLOC*.
-# Change to *env* if scheduler should make binding decision but not do the binding itself.
-#$ -binstance set
-
-# Allows to set resource requests like memory (1 GB [in bytes])
-# to set runtime limits (1 hour [in seconds])
-# or to influence scheduler resource selection (job will be executed in all.q queue)
-#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q
-
-# Tag the job so that it can be identified later on (e.g. in a JSV script before
-# submission so the job can get adapted or for filtering later on)
-#$ -ac application=clustermq,hostname={{ master }}
+#$ -terse                        # Show job ID
+#$ -N {{ job_name }}             # Job name
+#$ -j y                          # Combine stdout/stderr into one file
+#$ -o {{ log_file | /dev/null }} # Output file
+#$ -cwd                          # Use cwd as working directory
+#$ -V                            # Export all environment variables to the job
+                                 # Depending on security settings might require a
+                                 # cluster manager to set ENABLE_SUBMIT_LIB_PATH=1 as
+                                 # *qmaster_param* to export *LD_LIBRARY_PATH*
+#$ -t 1-{{ n_jobs }}             # Spawns workload as tasks of an array job
+#$ -pe mytestpe {{ cores | 1 }}  # Allocate one slot per task
+#$ -bunit C                      # Allocate *power core(s)* per slot
+#$ -bamount {{ threads | 1 }}    # Allocate *one* power core per slot
+#$ -bstrategy packed             # *Pack* cores on a host to share NUMA nodes and caches
+#$ -btype host                   # Bind per host
+#$ -binstance set                # Use HWLOC to bind cores
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q # Resource requests and limits
+#$ -ac application=clustermq,hostname={{ master }} # Tag the job
 
 ulimit -v $(( 1024 * {{ memory | 4096 }} ))
 CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'
@@ -580,41 +556,22 @@ To supply your own template, save the contents below with any desired changes
 to a file and have `clustermq.template` point to it.
 
 ```{sh eval=FALSE}
-# Name of the job visible in GCS
-#$ -N {{ job_name }}
-
-# Join error and output file.
-#$ -j y
-
-# Location of the output file
-#$ -o {{ log_file | /dev/null }}
-
-# Start R job in the working directory
-#$ -cwd
-
-# Export the full environment to the R job (e.g if *LD_LIBRARY_PATH* is required).
-# Depending on security settings might require a cluster manager to set
-# ENABLE_SUBMIT_LIB_PATH=1 as *qmaster_param*
-#$ -V
-
-# Spawns workload as tasks of an array job into the scheduler (one job with multiple tasks)
-#$ -t 1-{{ n_jobs }}
-
-# Each array task will allocate one slot in the cluster, if not other specified.
-#$ -pe mytestpe {{ cores | 1 }}
-
-# Per slot the job will get one power core (C) assuming R code is single-threaded, if not other specified.
-#$ -bunit C
-#$ -bamount {{ threads | 1 }}
-
-# Allows to set resource requests like memory (1 GB [in bytes])
-# to set runtime limits (1 hour [in seconds])
-# or to influence scheduler resource selection (job will be executed in all.q queue)
-#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q
-
-# Tag the job so that it can be identified later on (e.g. in a JSV script before
-# submission so the job can get adapted or for filtering later on)
-#$ -ac application=clustermq,hostname={{ master }}
+# Name of the job visible in OCS
+#$ -terse                        # Show job ID
+#$ -N {{ job_name }}             # Job name
+#$ -j y                          # Combine stdout/stderr into one file
+#$ -o {{ log_file | /dev/null }} # Output file
+#$ -cwd                          # Use cwd as working directory
+#$ -V                            # Export all environment variables to the job
+                                 # Depending on security settings might require a
+                                 # cluster manager to set ENABLE_SUBMIT_LIB_PATH=1 as
+                                 # *qmaster_param* to export *LD_LIBRARY_PATH*
+#$ -t 1-{{ n_jobs }}             # Spawns workload as tasks of an array job
+#$ -pe mytestpe {{ cores | 1 }}  # Allocate one slot per task
+#$ -bunit C                      # Allocate *power core(s)* per slot
+#$ -bamount {{ threads | 1 }}    # Allocate *one* power core per slot
+#$ -l mem_free={{ memory | 1073741824 }},h_rt={{ walltime | 3600 }},q=all.q # Resource requests and limits
+#$ -ac application=clustermq,hostname={{ master }} # Tag the job
 
 ulimit -v $(( 1024 * {{ memory | 4096 }} ))
 CMQ_AUTH={{ auth }} R --no-save --no-restore -e 'clustermq:::worker("{{ master }}")'
@@ -634,7 +591,6 @@ In this file, `#$-*` defines command-line arguments to the `qsub` program.
 
 Once this is done, the package will use your settings and no longer warn you of
 the missing options.
-
 
 ### SGE
 


### PR DESCRIPTION
As discussed in #341, this PR adds native backend support for OCS and GCS.

Summary of changes:
* Added OCS and GCS as separate scheduler backends.
* Implemented dedicated submission templates for both backends.
* Switched the primary job identifier from job name to job ID (job names are not guaranteed to be unique).
* Added a finalize handler.
* Adjusted cleanup handling (the current SGE implementation appears to reset the flag before finalize() is executed).
* Added documentation, including references to OCS/GCS manuals and inline template documentation.
* Added CLion's .idea/ to .gitignore.

Testing:
* Verified functionality with OCS/GCS 9.1.0beta1.
* Added an automated test for clustermq + GCS integration.
* Added an R Mandelbrot example to GCS that demonstrates usage.
* Opened a Jira issue regarding qsub -terse handling in 9.0.x (expected to be fixed in 9.0.12).
* Added howto to GCS distribution with references to you and this project

Many thanks for the helpful feedback and suggestions.

Best regards,
Ernst